### PR TITLE
Fix creating contract in node

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ export default {
     });
 
     // Override to support `contract.new`
-    web3in.eth.sendTransaction = web3in.qkc.sendTransaction; // eslint-disable-line
+    web3in.eth.sendTransaction = web3in.qkc.sendTransaction.bind(web3in.qkc); // eslint-disable-line
     web3in.eth.getTransactionReceipt = web3in.qkc.getTransactionReceipt; // eslint-disable-line
     web3in.eth.getCode = web3in.qkc.getCode; // eslint-disable-line
   },


### PR DESCRIPTION
during `contract.new`, we override `web3.eth.sendTransaction` to `web3.qkc.sendTransaction`, which will check if private key / address is set or not (which happens in node env). however, without binding with the `web3.qkc` object, `this.address` won't be correctly resolved, leading to failures mentioned in [this gist comment](https://gist.github.com/qcgg/1ab0352c5b2299270b5795648cca83d8#gistcomment-2705534) thanks to @lcinacio 